### PR TITLE
Release for v0.1.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,42 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## [v0.1.1](https://github.com/michimani/cfkvs/compare/v0.1.0...v0.1.1) - 2024-09-04
+- add tagpr by @michimani in https://github.com/michimani/cfkvs/pull/25
+- fix: workflow token by @michimani in https://github.com/michimani/cfkvs/pull/27
+
+## [v0.1.0](https://github.com/michimani/cfkvs/compare/v0.0.10...v0.1.0) - 2024-09-02
+- release v0.1.0 by @michimani in https://github.com/michimani/cfkvs/pull/22
+
+## [v0.0.10](https://github.com/michimani/cfkvs/compare/v0.0.7...v0.0.10) - 2024-09-02
+
+## [v0.0.7](https://github.com/michimani/cfkvs/compare/v0.0.6...v0.0.7) - 2024-09-02
+
+## [v0.0.6](https://github.com/michimani/cfkvs/compare/v0.0.1...v0.0.6) - 2024-09-02
+
+## [v0.0.1](https://github.com/michimani/cfkvs/compare/v0.0.0...v0.0.1) - 2024-09-02
+
+## [v0.0.0](https://github.com/michimani/cfkvs/commits/v0.0.0) - 2024-09-02
+- feat: get an item by @michimani in https://github.com/michimani/cfkvs/pull/2
+- chore: add CREDIT file by @michimani in https://github.com/michimani/cfkvs/pull/7
+- feat: put an item by @michimani in https://github.com/michimani/cfkvs/pull/8
+- feat: delete an item by @michimani in https://github.com/michimani/cfkvs/pull/9
+- feat: create a key-value store by @michimani in https://github.com/michimani/cfkvs/pull/10
+- feat: output as json or table by @michimani in https://github.com/michimani/cfkvs/pull/12
+- change: use flags by @michimani in https://github.com/michimani/cfkvs/pull/16
+- feat: import from S3 by @michimani in https://github.com/michimani/cfkvs/pull/17
+- feat: sync with S3 Object by @michimani in https://github.com/michimani/cfkvs/pull/18
+- release v0.0.0 by @michimani in https://github.com/michimani/cfkvs/pull/20


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* add tagpr by @michimani in https://github.com/michimani/cfkvs/pull/25
* fix: workflow token by @michimani in https://github.com/michimani/cfkvs/pull/27


**Full Changelog**: https://github.com/michimani/cfkvs/compare/v0.1.0...v0.1.1