### PR TITLE
Release for v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.2](https://github.com/michimani/cfkvs/compare/v0.1.1...v0.1.2) - 2024-09-04
+- feat: descrbe a key value store by @michimani in https://github.com/michimani/cfkvs/pull/29
+
 ## [v0.1.1](https://github.com/michimani/cfkvs/compare/v0.1.0...v0.1.1) - 2024-09-04
 - add tagpr by @michimani in https://github.com/michimani/cfkvs/pull/25
 - fix: workflow token by @michimani in https://github.com/michimani/cfkvs/pull/27


### PR DESCRIPTION
This pull request is for the next release as v0.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: descrbe a key value store by @michimani in https://github.com/michimani/cfkvs/pull/29


**Full Changelog**: https://github.com/michimani/cfkvs/compare/v0.1.1...v0.1.2