### PR TITLE
Release for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.1.4](https://github.com/michimani/cfkvs/compare/v0.1.3...v0.1.4) - 2024-09-24
+- chore: add libs tests by @michimani in https://github.com/michimani/cfkvs/pull/37
+- chore: add tests for internal/output by @michimani in https://github.com/michimani/cfkvs/pull/40
+- chore: add tests for internal/commands by @michimani in https://github.com/michimani/cfkvs/pull/42
+
 ## [v0.1.3](https://github.com/michimani/cfkvs/compare/v0.1.2...v0.1.3) - 2024-09-12
 - feat: sync items with a JSON file by @michimani in https://github.com/michimani/cfkvs/pull/34
 


### PR DESCRIPTION
This pull request is for the next release as v0.1.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore: add libs tests by @michimani in https://github.com/michimani/cfkvs/pull/37
* chore: add tests for internal/output by @michimani in https://github.com/michimani/cfkvs/pull/40
* chore: add tests for internal/commands by @michimani in https://github.com/michimani/cfkvs/pull/42


**Full Changelog**: https://github.com/michimani/cfkvs/compare/v0.1.3...v0.1.4