### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.0](https://github.com/michimani/cfkvs/compare/v0.2.0...v0.3.0) - 2024-10-04
+- fix: list keys with next token by @michimani in https://github.com/michimani/cfkvs/pull/51
+- feature: delete a key value store by @michimani in https://github.com/michimani/cfkvs/pull/54
+- change: change function name by @michimani in https://github.com/michimani/cfkvs/pull/56
+
 ## [v0.2.0](https://github.com/michimani/cfkvs/compare/v0.1.4...v0.2.0) - 2024-10-01
 - chore: add tests for cli by @michimani in https://github.com/michimani/cfkvs/pull/44
 - change: move sync sub-command to under the kvs command by @michimani in https://github.com/michimani/cfkvs/pull/47


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: list keys with next token by @michimani in https://github.com/michimani/cfkvs/pull/51
* feature: delete a key value store by @michimani in https://github.com/michimani/cfkvs/pull/54
* change: change function name by @michimani in https://github.com/michimani/cfkvs/pull/56


**Full Changelog**: https://github.com/michimani/cfkvs/compare/v0.2.0...v0.3.0